### PR TITLE
refactor: split server.js into app.js & server.js

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,0 +1,44 @@
+// app.js for use with Jest
+
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '.env') });
+
+require('./db');
+
+const express = require('express');
+const cors = require('cors');
+
+// --- Routes ---
+const loginRoutes = require('./routes/login.routes');
+const userRoutes = require('./routes/user.routes');
+const devRoutes = require('./routes/dev.routes');
+const userGamesRoutes = require('./routes/userGames.routes');
+const globalGamesRoures = require('./routes/globalGames.routes');
+//const passwordRoutes = require('./routes/password.routes');
+
+const app = express();
+
+// --- Avatar Static Files ---
+app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
+
+// --- Middleware ---
+app.use(cors({ origin: true, credentials: true }));
+
+app.use(express.json({ limit: '50mb' }));
+app.use(express.urlencoded({ limit: '50mb', extended: true }));
+
+app.use('/api/auth', loginRoutes);
+app.use('/api/user', userRoutes);
+app.use('/api/dev', devRoutes);
+app.use('/api/user/games', userGamesRoutes);
+app.use('/api/globalgames', globalGamesRoures);
+//app.use('/api/password/', passwordRoutes);
+
+app.get('/health', (_req, res) => res.status(200).json({ ok: true }));
+app.use((_req, res) => res.status(404).json({ message: 'Not found' }));
+app.use((err, _req, res, _next) => {
+  console.error('Unhandled error:', err);
+  res.status(500).json({ message: 'Server error.' });
+});
+
+module.exports = app;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,43 +1,4 @@
-const path = require('path');
-require('dotenv').config({ path: path.join(__dirname, '.env') });
-
-require('./db');
-
-const express = require('express');
-const cors = require('cors');
-
-// --- Routes ---
-const loginRoutes = require('./routes/login.routes');
-const userRoutes = require('./routes/user.routes');
-const devRoutes = require('./routes/dev.routes');
-const userGamesRoutes = require('./routes/userGames.routes');
-const globalGamesRoures = require('./routes/globalGames.routes');
-//const passwordRoutes = require('./routes/password.routes');
-
-const app = express();
-
-// --- Avatar Static Files ---
-app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
-
-// --- Middleware ---
-app.use(cors({ origin: true, credentials: true }));
-
-app.use(express.json({ limit: '50mb' }));
-app.use(express.urlencoded({ limit: '50mb', extended: true }));
-
-app.use('/api/auth', loginRoutes);
-app.use('/api/user', userRoutes);
-app.use('/api/dev', devRoutes);
-app.use('/api/user/games', userGamesRoutes);
-app.use('/api/globalgames', globalGamesRoures);
-//app.use('/api/password/', passwordRoutes);
-
-app.get('/health', (_req, res) => res.status(200).json({ ok: true }));
-app.use((_req, res) => res.status(404).json({ message: 'Not found' }));
-app.use((err, _req, res, _next) => {
-  console.error('Unhandled error:', err);
-  res.status(500).json({ message: 'Server error.' });
-});
+const app = require("./app");
 
 const port = process.env.PORT || 8080;
 app.listen(port, () => console.log(`🚀 API listening on port ${port}`));


### PR DESCRIPTION
This PR splits the pre-existing `server.js` file (which handles both app setup _and_ server port listening) into a separate `app.js` (which handles configuring the Express app, including middleware, routing, etc) and `server.js`, which imports `app.js` and does server stuff. 